### PR TITLE
Add support for SSL version.

### DIFF
--- a/lib/config.ini
+++ b/lib/config.ini
@@ -3,5 +3,5 @@ sdk_version = MELI-PYTHON-SDK-1.0.0
 api_root_url = https://api.mercadolibre.com
 auth_url = https://auth.mercadolibre.com/authorization
 oauth_url = /oauth/token
-ssl_version = PROTOCOL_SSLv3
+ssl_version = PROTOCOL_TLSv1
 

--- a/lib/config.ini
+++ b/lib/config.ini
@@ -3,3 +3,5 @@ sdk_version = MELI-PYTHON-SDK-1.0.0
 api_root_url = https://api.mercadolibre.com
 auth_url = https://auth.mercadolibre.com/authorization
 oauth_url = /oauth/token
+ssl_version = PROTOCOL_SSLv3
+

--- a/lib/meli.py
+++ b/lib/meli.py
@@ -20,7 +20,7 @@ class Meli(object):
         parser = SafeConfigParser()
         parser.read(os.path.dirname(os.path.abspath(__file__))+'/config.ini')
 
-        self.requests_session = requests.Session()
+        self._requests = requests.Session()
         try:
             self.SSL_VERSION = parser.get('config', 'ssl_version')
             self._requests.mount('https://', SSLAdapter(ssl_version=getattr(ssl, self.SSL_VERSION)))

--- a/lib/meli.py
+++ b/lib/meli.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import requests
+import ssl
 
 class Meli(object):
     def __init__(self, client_id, client_secret, access_token=None, refresh_token=None):

--- a/lib/meli.py
+++ b/lib/meli.py
@@ -1,12 +1,13 @@
  #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import re
-import os
-import requests
-from urllib import urlencode
 from ConfigParser import SafeConfigParser
+from ssl_helper import SSLAdapter
+from urllib import urlencode
 import json
+import os
+import re
+import requests
 
 class Meli(object):
     def __init__(self, client_id, client_secret, access_token=None, refresh_token=None):
@@ -17,6 +18,13 @@ class Meli(object):
 
         parser = SafeConfigParser()
         parser.read(os.path.dirname(os.path.abspath(__file__))+'/config.ini')
+
+        self.requests_session = requests.Session()
+        try:
+            self.SSL_VERSION = parser.get('config', 'ssl_version')
+            self._requests.mount('https://', SSLAdapter(ssl_version=getattr(ssl, self.SSL_VERSION)))
+        except:
+            self._requests = requests
 
         self.API_ROOT_URL = parser.get('config', 'api_root_url')
         self.SDK_VERSION = parser.get('config', 'sdk_version')
@@ -34,7 +42,7 @@ class Meli(object):
         headers = {'Accept': 'application/json', 'User-Agent':self.SDK_VERSION, 'Content-type':'application/json'}
         uri = self.make_path(self.OAUTH_URL)
 
-        response = requests.post(uri, params=urlencode(params), headers=headers)
+        response = self._requests.post(uri, params=urlencode(params), headers=headers)
 
         if response.status_code == requests.codes.ok:
             response_info = response.json()
@@ -55,7 +63,7 @@ class Meli(object):
             headers = {'Accept': 'application/json', 'User-Agent':self.SDK_VERSION, 'Content-type':'application/json'}
             uri = self.make_path(self.OAUTH_URL)
 
-            response = requests.post(uri, params=urlencode(params), headers=headers, data=params)
+            response = self._requests.post(uri, params=urlencode(params), headers=headers, data=params)
 
             if response.status_code == requests.codes.ok:
                 response_info = response.json()
@@ -72,7 +80,7 @@ class Meli(object):
     def get(self, path, params={}):
         headers = {'Accept': 'application/json', 'User-Agent':self.SDK_VERSION, 'Content-type':'application/json'}
         uri = self.make_path(path)
-        response = requests.get(uri, params=urlencode(params), headers=headers)
+        response = self._requests.get(uri, params=urlencode(params), headers=headers)
         return response
 
     def post(self, path, body=None, params={}):
@@ -81,7 +89,7 @@ class Meli(object):
         if body:
             body = json.dumps(body)
 
-        response = requests.post(uri, data=body, params=urlencode(params), headers=headers)
+        response = self._requests.post(uri, data=body, params=urlencode(params), headers=headers)
         return response
 
     def put(self, path, body=None, params={}):
@@ -90,19 +98,19 @@ class Meli(object):
         if body:
             body = json.dumps(body)
 
-        response = requests.put(uri, data=body, params=urlencode(params), headers=headers)
+        response = self._requests.put(uri, data=body, params=urlencode(params), headers=headers)
         return response
 
     def delete(self, path, params={}):
         headers = {'Accept': 'application/json', 'User-Agent':self.SDK_VERSION, 'Content-type':'application/json'}
         uri = self.make_path(path)
-        response = requests.delete(uri, params=params, headers=headers)
+        response = self._requests.delete(uri, params=params, headers=headers)
         return response
 
     def options(self, path, params={}):
         headers = {'Accept': 'application/json', 'User-Agent':self.SDK_VERSION, 'Content-type':'application/json'}
         uri = self.make_path(path)
-        response = requests.options(uri, params=urlencode(params), headers=headers)
+        response = self._requests.options(uri, params=urlencode(params), headers=headers)
         return response
 
     def make_path(self, path, params={}):

--- a/lib/ssl_helper.py
+++ b/lib/ssl_helper.py
@@ -1,0 +1,20 @@
+ #!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.poolmanager import PoolManager
+import ssl
+
+
+class SSLAdapter(HTTPAdapter):
+    """"Transport adapter" that allows us to use SSLv3."""
+    def __init__(self, ssl_version=None, **kwargs):
+        self.ssl_version = ssl_version
+        super(SSLAdapter, self).__init__(**kwargs)
+
+    def init_poolmanager(self, connections, maxsize, block=False):
+        self.poolmanager = PoolManager(num_pools=connections,
+                                       maxsize=maxsize,
+                                       block=block,
+                                       ssl_version=self.ssl_version)
+


### PR DESCRIPTION
With the current version of SSL used by the requests library (SSLv23), the connection with the MELI webservice will drop with a timeout.

This fix it. 
How? Selecting a (and is configured with) SSL version that works (SSLv3).

Bug from OPENSSL:
http://askubuntu.com/questions/116020/python-https-requests-urllib2-to-some-sites-fail-on-ubuntu-12-04-without-proxy