### PR TITLE
always set expires_in when an access_token is obtained

### DIFF
--- a/lib/meli.py
+++ b/lib/meli.py
@@ -50,11 +50,11 @@ class Meli(object):
         if response.status_code == requests.codes.ok:
             response_info = response.json()
             self.access_token = response_info['access_token']
+            self.expires_in = response_info['expires_in']
             if 'refresh_token' in response_info:
                 self.refresh_token = response_info['refresh_token']
             else:
                 self.refresh_token = '' # offline_access not set up
-                self.expires_in = response_info['expires_in']
 
             return self.access_token
         else:


### PR DESCRIPTION
The current python-sdk only sets the `expires_in` field when there's no `refresh_token` in the response.

However the [API docs](http://developers.mercadolibre.com/server-side/) state that this field applies to the `access_token` and it's returned when asking for a token, whether the app has `offline_access` scope or not.
