### PR TITLE
Add state parameter support to auth_url for csrf protection

### DIFF
--- a/lib/meli.py
+++ b/lib/meli.py
@@ -35,8 +35,10 @@ class Meli(object):
         self.OAUTH_URL = parser.get('config', 'oauth_url')
 
     #AUTH METHODS
-    def auth_url(self,redirect_URI):
+    def auth_url(self, redirect_URI, state=None):
         params = {'client_id':self.client_id,'response_type':'code','redirect_uri':redirect_URI}
+        if state:
+            params['state'] = state
         url = self.AUTH_URL  + '/authorization' + '?' + urlencode(params)
         return url
 


### PR DESCRIPTION
As per [Section 4.4.1.8 of RFC6819](https://tools.ietf.org/html/rfc6819#section-4.4.1.8), the state parameter should be used in the `authentication_code` flow to prevent CSRF attacks.

In the specific case of mercadolibre, such an attack could be used to link a user's account in a third party service with the attacker's account on mercadolibre, letting the attacker rip the benefits of the user's sales.

The authorization server correctly reflects the state parameter back if it's added in the request.

This PR adds it to the python-sdk in a backwards compatible way.
