### PR TITLE
Using response.ok instead of response.status_code == requests.codes.ok

### DIFF
--- a/lib/meli.py
+++ b/lib/meli.py
@@ -47,7 +47,7 @@ class Meli(object):
 
         response = self._requests.post(uri, params=urlencode(params), headers=headers)
 
-        if response.status_code == requests.codes.ok:
+        if response.ok:
             response_info = response.json()
             self.access_token = response_info['access_token']
             if 'refresh_token' in response_info:
@@ -69,7 +69,7 @@ class Meli(object):
 
             response = self._requests.post(uri, params=urlencode(params), headers=headers, data=params)
 
-            if response.status_code == requests.codes.ok:
+            if response.ok:
                 response_info = response.json()
                 self.access_token = response_info['access_token']
                 self.refresh_token = response_info['refresh_token']


### PR DESCRIPTION
http://docs.python-requests.org/en/master/api/#requests.Response.ok

`response.status_code == requests.codes.ok` checks _only_ for 200 OK, while `response.ok` returns `True` if the status code is not >= 400.